### PR TITLE
Revert d8ea36bcfc3d4894e40de2731fa3824903598799

### DIFF
--- a/src/lib/widget/Clock.svelte
+++ b/src/lib/widget/Clock.svelte
@@ -2,15 +2,11 @@
     import { onMount } from 'svelte';
     import { Card } from 'flowbite-svelte';
 
-    let now = new Date();
-    let date = now.toLocaleDateString();
-    let time = now.toLocaleTimeString();
+    let time = new Date();
 
     onMount(() => {
         const interval = setInterval(() => {
-            now = new Date();
-            date = now.toLocaleDateString();
-            time = now.toLocaleTimeString();
+            time = new Date();
         }, 1000);
 
         return () => {
@@ -19,7 +15,7 @@
     });
 </script>
 
-<Card href="https://ichipol.g.hiroshima-cu.ac.jp/uprx/MobileShibbolethAuthServlet" class="w-12/12 max-w-none">
-    <span class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white text-center" id="main-clock">{time}</span>
-    <p class="font-normal text-gray-700 dark:text-gray-400 leading-tight text-center" id="main-date">{date}</p>  
+<Card href="https://ichipol.g.hiroshima-cu.ac.jp/uprx/MobileShibbolethAuthServlet" class="w-12/12  max-w-none">
+    <span class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white text-center" id="main-clock">{time.toLocaleTimeString()}</span>
+    <p class="font-normal text-gray-700 dark:text-gray-400 leading-tight text-center" id="main-date">{time.toLocaleDateString()}</p>  
 </Card>


### PR DESCRIPTION
当該コミットは述べられている問題を何一つ改善していないため、これを revert します。

そもそも、この問題はサーバ側で生成された HTML が（恐らく C ロカールかつ GMT の）時刻が埋め込まれた状態で配信されることに起因していると考えられます。

This reverts commit d8ea36bcfc3d4894e40de2731fa3824903598799.